### PR TITLE
Executable Binary renamed to ws 

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
-          bin: ws-cli
+          bin: ws
           # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,16 @@ license = "MIT"
 keywords = ["workspace", "cli", "cargo"]
 categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 
+# use in Github workflow `release`
+[[bin]]
+name = "ws"
+path = "src/main.rs"
+
+# Used when Bunding for OSX
+[[bin]]
+name = "ws-cli"
+path = "src/main.rs"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,15 +26,16 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 clap = { version = "4.4.11", features = ["cargo", "derive", "string"] }
 toml_edit = "0.21.0"
 
+# Used when Bunding for OSX
 [package.metadata.bundle]
-name = "ws-cli"                                                              # The name of your application
-identifier = "com.codeitlikemiley.ws-cli"                                    # The bundle identifier of your application
+name = "ws"                                                              # The name of your application
+identifier = "com.codeitlikemiley.ws"                                    # The bundle identifier of your application
 copyright = "Copyright (c) codeitlikemiley 2023. All rights reserved."
 category = "Developer Tool"
 short_description = "A Workspace CLI for managing GRPC Server Workspace"
 long_description = "A Workspace CLI for managing GRPC Server Workspace"
 version = "0.1.0"                                                        # Version of your application
-osx_url_schemes = ["com.codeitlikemiley.ws-cli"]
+osx_url_schemes = ["com.codeitlikemiley.ws"]
 script = "scripts/postinstall"                                           # Path to your postinstall script
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Uriah <codeitlikemiley@gmail.com>"]
 description = "Manage your workspace with ease"

--- a/README.md
+++ b/README.md
@@ -14,49 +14,13 @@ Note: on MacOS you might need to go to System Preferences > Security & Privacy >
 
 Note: on Windows you might need to Add the command to ENV PATH
 
-or Install via Cargo
+
+2. Install via Cargo , by default it would install both `ws` and `ws-cli` command, the command below would only install `ws` command
 
 ```sh
-cargo install ws-cli
+cargo install ws-cli --bin ws
 ```
 
-Note: if you dont like typing ws-cli you can alias it to ws
-
-2. Build it from source
-
-
-Clone
-
-```sh
-git clone htps://github.com/codeitlikemiley/ws-cli.git ws
-cd ws
-```
-
-**For MacOS**
-```sh
-./provision.sh
-# you can use ws command instead of ws-cli (longer)
-```
-
-**For Linux**
-
-```sh
-cargo build --release
-mv ./target/release/ws-cli /usr/local/bin/ws
-chmod +x /usr/local/bin/ws
-```
-
-**For Windows**
-
-```powershell
-cargo build --release
-
-# Replace 'YourUsername' with your actual username
-Move-Item .\target\release\ws-cli.exe C:\Users\YourUsername\bin\ws.exe
-
-# Again, replace 'YourUsername' with your actual username
-$env:Path += ";C:\Users\YourUsername\bin"
-```
 
 ## Developer Workflow
 

--- a/provision.sh
+++ b/provision.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cargo clean
-rm ws-cli.pkg
+rm ws.pkg
 cargo zigbuild --release
 cargo bundle --release
-pkgbuild --root ./target/release/bundle/osx/ws-cli.app --install-location "/Applications/ws-cli.app" --identifier com.codeitlikemiley.ws-cli --version 0.1.0 --scripts ./scripts ws-cli.pkg
+pkgbuild --root ./target/release/bundle/osx/ws.app --install-location "/Applications/ws.app" --identifier com.codeitlikemiley.ws --version 0.1.0 --scripts ./scripts ws.pkg

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -17,4 +17,4 @@ if [ -L "$USER_HOME/.local/bin/ws" ]; then
 fi
 
 # Create the symlink in ~/.local/bin
-ln -s "/Applications/ws-cli.app/Contents/MacOS/ws-cli" "$USER_HOME/.local/bin/ws"
+ln -s "/Applications/ws.app/Contents/MacOS/ws-cli" "$USER_HOME/.local/bin/ws"


### PR DESCRIPTION
Github Release now output `ws` bin or exe, that you can download and Add to your path.

Cargo Install , default behaviour to install both `ws` and `ws-cli` , but can be cherry pick to install with 

```sh
cargo install ws-cli --bin ws
```

If you wanna build from source on macOS , the `./provision.sh` would properly create a `ws.app` and linked symlinked from
`ws-cli` to `~/.local/bin/ws` 

 